### PR TITLE
Nitpick: fix documented field on Page class

### DIFF
--- a/python3/trec_car/read_data.py
+++ b/python3/trec_car/read_data.py
@@ -323,7 +323,7 @@ class Section(PageSkeleton):
     """
     A section of a Wikipedia page.
 
-    .. attribute:: title
+    .. attribute:: heading
 
        :rtype: str
 


### PR DESCRIPTION
It's "header", not "title" :)
I would have documented "headerId" here as well, but I don't know what type that's supposed to be.