### PR TITLE
repair Null categoryNames read

### DIFF
--- a/python3/trec_car/read_data.py
+++ b/python3/trec_car/read_data.py
@@ -225,7 +225,7 @@ class PageMetadata(object):
     def __str__(self):
         redirStr = ("" if self.redirectNames is None else (" redirected = "+", ".join([name for name in self.redirectNames])))
         disamStr = ("" if self.disambiguationNames is None else (" disambiguated = "+", ".join([name for name in self.disambiguationNames])))
-        catStr = ("" if self.redirectNames is None else (" categories = "+", ".join([name for name in self.categoryNames])))
+        catStr = ("" if self.categoryNames is None else (" categories = "+", ".join([name for name in self.categoryNames])))
         inlinkStr = ("" if self.inlinkIds is None else (" inlinks = "+", ".join([name for name in self.inlinkIds])))
         # inlinkAnchorStr = str (self.inlinkAnchors)
         inlinkAnchorStr = ("" if self.inlinkAnchors is None else \


### PR DESCRIPTION
see [issue #26](https://github.com/TREMA-UNH/trec-car-tools/issues/26) bug in read_data.py on PageMetadata => str fonction (categoryNames) 